### PR TITLE
Align release workflow with CI on build/test job wiring

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,49 @@ jobs:
           name: sbom
           path: plugin/build/reports/cyclonedx/bom.xml
 
-  # Developer tests: every test class NOT named *IT.
+  # Head of the pipeline: this job compiles everything once — the distributable plugin (`buildPlugin`) AND
+  # the test code (`testClasses`) — and publishes the result through the shared Gradle build cache. Both
+  # test jobs depend on it and restore that cache, so they no longer recompile what has already been built
+  # here. A compilation failure is therefore also reported as such, in one place, instead of surfacing
+  # identically in both test jobs.
+  build:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+    steps:
+      # The local composite action can only be resolved once the repo is on disk.
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-gradle
+
+      - name: Build plugin
+        run: ./gradlew buildPlugin testClasses -Pversion=${{ github.ref_name }} --build-cache --stacktrace --info
+
+      # Must run here rather than inside the composite action: the cache can only be saved once the build
+      # has filled it, and a composite action cannot register a post-job step.
+      - name: Save shared build cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.gradle-build-cache
+          key: gradle-build-cache-${{ github.run_id }}
+
+      - name: Upload plugin artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: plugin-distribution
+          path: plugin/build/distributions/*.zip
+
+  # Developer tests: every test class NOT named *IT. The fast inner-loop suite.
   # Runs in parallel with the integration tests, both fed by the build job's cache.
   test-developer:
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - build
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
     steps:
       # The local composite action can only be resolved once the repo is on disk.
@@ -74,14 +112,22 @@ jobs:
           # An empty artifact would silently hide a broken path; fail loudly instead.
           if-no-files-found: error
 
-  # Integration tests: test classes named *IT. Runs at the same time as the developer tests,
-  # from the identical setup and off the same build-job cache.
+  # Integration tests: test classes named *IT — shipped-artifact smoke tests, the timing-based performance
+  # guards and the validation against the official Inno Setup example corpus. Runs at the same time as the
+  # developer tests, from the identical setup and off the same build-job cache.
   #
-  # WINDOWS: IsExampleScriptBuildIT compiles every official example with the real ISCC.exe, which exists on
-  # Windows only — hence the Windows runner and the Inno Setup installation.
+  # NETWORK: `integrationTest` depends on downloadInnoSetupExamples, which fetches the Examples/ directory of
+  # the pinned jrsoftware/issrc tag (see gradle/libs.versions.toml). Those third-party scripts are
+  # deliberately not checked in; the run is finalized by cleanInnoSetupExamples, which deletes them again.
+  # Only the derived fingerprints in language/script/src/test/resources/examples are committed.
+  #
+  # WINDOWS: IsExampleScriptBuildIT compiles every example with the real ISCC.exe, which exists on Windows
+  # only. The whole integration suite therefore runs on a Windows runner with Inno Setup installed.
   test-integration:
     runs-on: windows-latest
     needs: build
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
     steps:
       # The local composite action can only be resolved once the repo is on disk.
@@ -90,6 +136,7 @@ jobs:
 
       - uses: ./.github/actions/setup-gradle
 
+      # The build tests compile through the plugin's own pipeline, which needs a real compiler.
       - name: Install Inno Setup
         run: choco install innosetup --no-progress -y
         shell: pwsh
@@ -129,6 +176,7 @@ jobs:
   # on one of the supported products. See .claude/rules/plugin-verification.md.
   verify-plugin:
     runs-on: ubuntu-latest
+    # Gated on the tests: a red suite must stop the pipeline, not merely be reported next to it.
     needs: tests
 
     steps:
@@ -152,36 +200,6 @@ jobs:
         with:
           name: plugin-verification-report
           path: '**/build/reports/pluginVerifier/**'
-
-  # Head of the pipeline: compiles everything once — the distributable plugin AND the test code — and
-  # publishes the result through the shared Gradle build cache. Both test jobs depend on this job and
-  # restore that cache instead of recompiling the same sources themselves.
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      # The local composite action can only be resolved once the repo is on disk.
-      - uses: actions/checkout@v7
-
-      - uses: ./.github/actions/setup-gradle
-
-      - name: Build plugin
-        run: ./gradlew buildPlugin testClasses -Pversion=${{ github.ref_name }} --build-cache --stacktrace
-
-      # Must run here rather than inside the composite action: the cache can only be saved once the build
-      # has filled it, and a composite action cannot register a post-job step.
-      - name: Save shared build cache
-        if: always()
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ github.workspace }}/.gradle-build-cache
-          key: gradle-build-cache-${{ github.run_id }}
-
-      - name: Upload plugin artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: plugin-distribution
-          path: plugin/build/distributions/*.zip
 
   # Build the docs as a generation test (mkdocs --strict) before they get deployed.
   validate-docs:


### PR DESCRIPTION
The release pipeline already used the same build -> (developer test ||
integration test) -> tests graph as ci.yml, but the three jobs it is made
of had drifted apart from their CI counterparts in ways that affect how
they actually run:

* build, test-developer and test-integration now all set
  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24, so the release jobs execute the
  JavaScript actions on the same Node runtime as CI does.
* The build job logs with --info like its CI counterpart, so a release
  build failure is diagnosable from the same output level.
* test-developer declares its dependency as a list, matching CI.
* The build job moves to the head of the file, ahead of the two test
  jobs, so the file order reflects the execution order as in ci.yml.
* The job comments (build as pipeline head, integration test network and
  Windows requirements, verify-plugin test gate) are taken over from CI.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013cXLJGDvka6eD5o7waMd1g